### PR TITLE
feat!: com.algorandfoundation -> foundation.algorand namespace ENG-545

### DIFF
--- a/androidModule/build.gradle
+++ b/androidModule/build.gradle
@@ -1,5 +1,5 @@
 version = project.property('version')
-group = "com.algorandfoundation.xhdwalletapi"
+group = "foundation.algorand.xhdwalletapi"
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
@@ -15,7 +15,7 @@ android {
 
     defaultConfig {
         archivesBaseName = "XHDWalletAPI-Android"
-        namespace "com.algorandfoundation.xhdwalletapi"
+        namespace "foundation.algorand.xhdwalletapi"
         minSdkVersion 26
         targetSdkVersion 34
         versionCode 16

--- a/androidModule/src/main/kotlin/foundation/algorand/xhdwalletapi/XHDWalletAPIAndroid.kt
+++ b/androidModule/src/main/kotlin/foundation/algorand/xhdwalletapi/XHDWalletAPIAndroid.kt
@@ -15,12 +15,11 @@
  * limitations under the License.
  */
 
-package com.algorandfoundation.xhdwalletapi
+package foundation.algorand.xhdwalletapi
 
-import com.goterl.lazysodium.LazySodiumJava
-import com.goterl.lazysodium.SodiumJava
-import com.goterl.lazysodium.utils.LibraryLoader
+import com.goterl.lazysodium.LazySodiumAndroid
+import com.goterl.lazysodium.SodiumAndroid
 
-open class XHDWalletAPIJVM(private var seed: ByteArray) : XHDWalletAPIBase(seed) {
-    override val lazySodium = LazySodiumJava(SodiumJava(LibraryLoader.Mode.PREFER_BUNDLED))
+class XHDWalletAPIAndroid(private var seed: ByteArray) : XHDWalletAPIBase(seed) {
+    override val lazySodium = LazySodiumAndroid(SodiumAndroid())
 }

--- a/jvmModule/build.gradle.kts
+++ b/jvmModule/build.gradle.kts
@@ -6,7 +6,7 @@
  */
 
 version = project.property("version") as String
-group = "com.algorandfoundation.xhdwalletapi"
+group = "foundation.algorand.xhdwalletapi"
 
 plugins {
     kotlin("plugin.serialization") version "1.9.22"

--- a/jvmModule/src/main/kotlin/foundation/algorand/xhdwalletapi/XHDWalletAPIJVM.kt
+++ b/jvmModule/src/main/kotlin/foundation/algorand/xhdwalletapi/XHDWalletAPIJVM.kt
@@ -15,11 +15,12 @@
  * limitations under the License.
  */
 
-package com.algorandfoundation.xhdwalletapi
+package foundation.algorand.xhdwalletapi
 
-import com.goterl.lazysodium.LazySodiumAndroid
-import com.goterl.lazysodium.SodiumAndroid
+import com.goterl.lazysodium.LazySodiumJava
+import com.goterl.lazysodium.SodiumJava
+import com.goterl.lazysodium.utils.LibraryLoader
 
-class XHDWalletAPIAndroid(private var seed: ByteArray) : XHDWalletAPIBase(seed) {
-    override val lazySodium = LazySodiumAndroid(SodiumAndroid())
+open class XHDWalletAPIJVM(private var seed: ByteArray) : XHDWalletAPIBase(seed) {
+    override val lazySodium = LazySodiumJava(SodiumJava(LibraryLoader.Mode.PREFER_BUNDLED))
 }

--- a/jvmModule/src/test/kotlin/com/algorandfoundation/xhdwalletapi/XHDWalletAPITest.kt
+++ b/jvmModule/src/test/kotlin/com/algorandfoundation/xhdwalletapi/XHDWalletAPITest.kt
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.algorandfoundation.xhdwalletapi
+package foundation.algorand.xhdwalletapi
 
 import cash.z.ecc.android.bip39.Mnemonics.MnemonicCode
 import cash.z.ecc.android.bip39.toSeed

--- a/jvmModule/src/test/kotlin/com/algorandfoundation/xhdwalletapi/testWithSandbox/AlgoLocalNetTest.kt
+++ b/jvmModule/src/test/kotlin/com/algorandfoundation/xhdwalletapi/testWithSandbox/AlgoLocalNetTest.kt
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.algorandfoundation.xhdwalletapi
+package foundation.algorand.xhdwalletapi
 
 import cash.z.ecc.android.bip39.Mnemonics.MnemonicCode
 import cash.z.ecc.android.bip39.toSeed

--- a/sharedModule/build.gradle.kts
+++ b/sharedModule/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     `java-library`
 }
 
-group = "com.algorandfoundation.xhdwalletapi"
+group = "foundation.algorand.xhdwalletapi"
 version = project.property("version") as String
 
 

--- a/sharedModule/src/main/kotlin/foundation/algorand/xhdwalletapi/XHDWalletAPIBase.kt
+++ b/sharedModule/src/main/kotlin/foundation/algorand/xhdwalletapi/XHDWalletAPIBase.kt
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.algorandfoundation.xhdwalletapi
+package foundation.algorand.xhdwalletapi
 
 // import com.fasterxml.jackson.dataformat.cbor.databind.CBORMapper // CBOR is not yet supported
 // across all platforms

--- a/sharedModule/src/main/kotlin/foundation/algorand/xhdwalletapi/utils.kt
+++ b/sharedModule/src/main/kotlin/foundation/algorand/xhdwalletapi/utils.kt
@@ -1,4 +1,4 @@
-package com.algorandfoundation.xhdwalletapi
+package foundation.algorand.xhdwalletapi
 
 import java.security.MessageDigest
 import java.util.Arrays


### PR DESCRIPTION
The point of this PR is to change the namespace from com.algorandfoundation to foundation.algorand, a domain we own. This is in order to prepare for publishing to Maven.

Directory paths are also changed.