### PR TITLE
ci: ensures that release/1.x -> main

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -3,14 +3,36 @@ name: Generate Release
 on:
   push:
     branches:
-      - "release/*"
-      - "main"
+      - main
+      - release/1.x
+  workflow_dispatch:
+
+concurrency: release
+
+permissions:
+  contents: write
+  issues: write
+  checks: write
 
 jobs:
   generate-release:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: write
+      packages: write
+      pull-requests: write
+      id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.BOT_ID }}
+          private-key: ${{ secrets.BOT_SK }}
+
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -35,4 +57,13 @@ jobs:
       - name: Semantic Release
         run: npx semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Merge Release -> Trunk
+        uses: devmasx/merge-branch@854d3ac71ed1e9deb668e0074781b81fdd6e771f
+        if: github.ref == 'refs/heads/release/1.x'
+        with:
+          type: now
+          from_branch: release/1.x
+          target_branch: main
+          github_token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
We want merges into release/1.x automatically to get merged back into main. Primarily this refers to changes to gradle.properties, which holds the version. But in general, it is necessary to ensure the two are align and that main does not go off into canary forks.