### PR TITLE
fix: bump dependencies and new Pera provided binaries AFE-866

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -44,7 +44,7 @@ jobs:
         run: sudo apt-get install -y libsodium-dev
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Initialize submodule, generate jars, and build (including tests)
         run: chmod +x initialize.sh && ./initialize.sh

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Currently there are two folders, one to create an .aar file for use in Android, 
 ## Requirements
 
 | Requirement | Version |
-| ----------- | ------- |
+| ----------- |---------|
 | Kotlin      | 1.9.22  |
 | Gradle      | 8.6     |
 | Android     | 26      |
-| Java        | 17      |
+| Java        | 21      |
 
 ## Installation - How to Incorporate Into Your Project
 

--- a/XHDWalletAPI-Android/build.gradle
+++ b/XHDWalletAPI-Android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "tech.yanand.maven-central-publish:tech.yanand.maven-central-publish.gradle.plugin:1.2.0"
+        classpath "tech.yanand.maven-central-publish:tech.yanand.maven-central-publish.gradle.plugin:1.3.0"
     }
 }
 
@@ -20,8 +20,7 @@ apply plugin: 'tech.yanand.maven-central-publish'
 
 
 android {
-    compileSdkVersion 34
-    buildToolsVersion "33.0.3"
+    compileSdkVersion 36
 
     buildFeatures {
         viewBinding = true
@@ -31,7 +30,7 @@ android {
         archivesBaseName = "XHDWalletAPI-Android"
         namespace "foundation.algorand.xhdwalletapi"
         minSdkVersion 26
-        targetSdkVersion 34
+        targetSdkVersion 36
         versionCode 16
         versionName version
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/XHDWalletAPI-Android/build.gradle
+++ b/XHDWalletAPI-Android/build.gradle
@@ -50,12 +50,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
     }
 
     kotlinOptions {
-        jvmTarget = "17"
+        jvmTarget = "21"
     }
 }
 

--- a/XHDWalletAPI-JVM/build.gradle.kts
+++ b/XHDWalletAPI-JVM/build.gradle.kts
@@ -13,8 +13,8 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 sourceSets {
@@ -26,13 +26,13 @@ sourceSets {
 dependencies {
     api(project(":sharedModule"))
     
-    testImplementation("com.algorand:algosdk:2.4.0")
+    testImplementation("com.algorand:algosdk:2.10.1")
     
     // Use the Kotlin JUnit 5 integration.
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
 
     // Use the JUnit 5 integration.
-    testImplementation("org.junit.jupiter:junit-jupiter-engine:5.8.2")
+    testImplementation("org.junit.jupiter:junit-jupiter-engine:6.0.0")
 
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
@@ -41,11 +41,11 @@ dependencies {
 
     // This dependency is used internally, and not exposed to consumers on their own compile
     // classpath.
-    implementation("com.google.guava:guava:31.0.1-jre")
+    implementation("com.google.guava:guava:33.5.0-jre")
 }
 
 // Apply a specific Java toolchain to ease working on different environments.
-java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
+java { toolchain { languageVersion.set(JavaLanguageVersion.of(21)) } }
 
 // Required for publishing to Maven Central.
 tasks.register<Jar>("javadocJar") {

--- a/XHDWalletAPI-JVM/src/main/kotlin/foundation/algorand/xhdwalletapi/XHDWalletAPIJVM.kt
+++ b/XHDWalletAPI-JVM/src/main/kotlin/foundation/algorand/xhdwalletapi/XHDWalletAPIJVM.kt
@@ -21,6 +21,6 @@ import com.goterl.lazysodium.LazySodiumJava
 import com.goterl.lazysodium.SodiumJava
 import com.goterl.lazysodium.utils.LibraryLoader
 
-open class XHDWalletAPIJVM(private var seed: ByteArray) : XHDWalletAPIBase(seed) {
+open class XHDWalletAPIJVM(seed: ByteArray) : XHDWalletAPIBase(seed) {
     override val lazySodium = LazySodiumJava(SodiumJava(LibraryLoader.Mode.PREFER_BUNDLED))
 }

--- a/XHDWalletAPI-JVM/src/test/kotlin/foundation/algorand/xhdwalletapi/XHDWalletAPITest.kt
+++ b/XHDWalletAPI-JVM/src/test/kotlin/foundation/algorand/xhdwalletapi/XHDWalletAPITest.kt
@@ -19,13 +19,11 @@ package foundation.algorand.xhdwalletapi
 
 import cash.z.ecc.android.bip39.Mnemonics.MnemonicCode
 import cash.z.ecc.android.bip39.toSeed
-import com.algorand.algosdk.crypto.Address
 import com.goterl.lazysodium.LazySodiumJava
 import com.goterl.lazysodium.SodiumJava
 import com.goterl.lazysodium.utils.Key
 import com.goterl.lazysodium.utils.LibraryLoader
 import java.util.Base64
-import kotlin.collections.component1
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertContains
@@ -33,6 +31,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertNotEquals
 import net.pwall.json.schema.JSONSchema
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.TestInstance
 
 /*
@@ -63,8 +62,9 @@ val ls: LazySodiumJava = LazySodiumJava(SodiumJava(LibraryLoader.Mode.PREFER_BUN
 
 class XHDWalletAPITest {
 
+        @Nested
         @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-        internal class KeyGenTests {
+        inner class KeyGenTests {
 
                 private lateinit var c: XHDWalletAPIJVM
 
@@ -890,8 +890,9 @@ class XHDWalletAPITest {
                 }
         }
 
+        @Nested
         @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-        internal class ValidateDataTests {
+        inner class ValidateDataTests {
 
                 // Inspired by
                 // https://github.com/algorandfoundation/ARCs/blob/d44a8e9ecb62152d419f1b4ea50d72baba6b5ba3/assets/arc-0052/contextual.api.crypto.spec.ts#L218
@@ -1269,8 +1270,9 @@ class XHDWalletAPITest {
                 }
         }
 
+        @Nested
         @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-        internal class SignTypedDataTests {
+        inner class SignTypedDataTests {
                 private lateinit var c: XHDWalletAPIJVM
 
                 @BeforeAll
@@ -1745,8 +1747,9 @@ class XHDWalletAPITest {
                 }
         }
 
+        @Nested
         @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-        internal class ECDHTests {
+        inner class ECDHTests {
 
                 private lateinit var alice: XHDWalletAPIJVM
                 private lateinit var bob: XHDWalletAPIJVM

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.1.4" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.0" apply false
-    id("com.android.library") version "8.1.4" apply false
+    id("com.android.application") version "8.13.0" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.21" apply false
+    id("com.android.library") version "8.13.0" apply false
     `java-library`
     kotlin("jvm") version "1.9.22"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,7 +15,7 @@ pluginManagement {
 
 plugins {
     // Apply the foojay-resolver plugin to allow automatic download of JDKs
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 dependencyResolutionManagement {

--- a/sharedModule/build.gradle.kts
+++ b/sharedModule/build.gradle.kts
@@ -41,8 +41,8 @@ java {
     targetCompatibility = JavaVersion.VERSION_17
 }
 
-tasks.withType<KotlinCompile> {
-    kotlinOptions {
-        jvmTarget = "17"
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile>().configureEach {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
     }
 }

--- a/sharedModule/build.gradle.kts
+++ b/sharedModule/build.gradle.kts
@@ -14,24 +14,24 @@ dependencies {
     api(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
     implementation(kotlin("stdlib"))
 
-    api("commons-codec:commons-codec:1.16.1")
-    api("net.java.dev.jna:jna:5.12.1")
-    api("com.goterl:resource-loader:2.0.2")
+    api("commons-codec:commons-codec:1.19.0")
+    api("net.java.dev.jna:jna:5.18.1")
+    api("com.goterl:resource-loader:2.1.0")
 
     // Bip39 implementation
-    api("cash.z.ecc.android:kotlin-bip39:1.0.7") 
+    api("cash.z.ecc.android:kotlin-bip39:1.0.9")
 
     // For data validation
-    api("net.pwall.json:json-kotlin-schema:0.46")
+    api("net.pwall.json:json-kotlin-schema:0.57")
 
     // https://mvnrepository.com/artifact/org.jetbrains.kotlinx
-    api("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
-    api("org.jetbrains.kotlinx:kotlinx-serialization-core:1.6.3")
+    api("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+    api("org.jetbrains.kotlinx:kotlinx-serialization-core:1.9.0")
     // https://mvnrepository.com/artifact/com.fasterxml.jackson.core
-    api("com.fasterxml.jackson.core:jackson-databind:2.16.1")
-    api("com.fasterxml.jackson.core:jackson-core:2.16.1")
-    api("org.msgpack:jackson-dataformat-msgpack:0.9.8")
-    api("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.16.1")
+    api("com.fasterxml.jackson.core:jackson-databind:2.20.0")
+    api("com.fasterxml.jackson.core:jackson-core:2.20.0")
+    api("org.msgpack:jackson-dataformat-msgpack:0.9.10")
+    api("com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.20.0")
 
 }
 

--- a/sharedModule/build.gradle.kts
+++ b/sharedModule/build.gradle.kts
@@ -37,12 +37,12 @@ dependencies {
 
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile>().configureEach {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
 }

--- a/sharedModule/src/main/kotlin/foundation/algorand/xhdwalletapi/XHDWalletAPIBase.kt
+++ b/sharedModule/src/main/kotlin/foundation/algorand/xhdwalletapi/XHDWalletAPIBase.kt
@@ -261,7 +261,7 @@ abstract class XHDWalletAPIBase(private var seed: ByteArray) {
    * @returns
    * - (z, c) where z is the 64-byte child key and c is the chain code
    */
-  internal fun deriveHardened(
+  fun deriveHardened(
           kl: ByteArray,
           kr: ByteArray,
           cc: ByteArray,


### PR DESCRIPTION
Ticket: AFE-866

Wait for https://github.com/algorandfoundation/lazysodium-java/pull/8 to be merged, then add that into this PR.

- deriveHardened was made public
- seed is no longer a private variable
(Pera changes)