### PR TITLE
feat: sign() and fix maven signing

### DIFF
--- a/XHDWalletAPI-JVM/src/test/kotlin/foundation/algorand/xhdwalletapi/XHDWalletAPITest.kt
+++ b/XHDWalletAPI-JVM/src/test/kotlin/foundation/algorand/xhdwalletapi/XHDWalletAPITest.kt
@@ -1272,6 +1272,71 @@ class XHDWalletAPITest {
 
         @Nested
         @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+        inner class SignTests {
+                private lateinit var c: XHDWalletAPIJVM
+
+                @BeforeAll
+                fun setup() {
+                        val seed =
+                                MnemonicCode(
+                                        "salon zoo engage submit smile frost later decide wing sight chaos renew lizard rely canal coral scene hobby scare step bus leaf tobacco slice".toCharArray()
+                                )
+                        c = XHDWalletAPIJVM(seed.toSeed())
+                }
+
+                fun simpleSignDataTest() {
+                        // Message to sign
+
+                        val data = """{"text":"Hello, World!"}""".trimIndent().toByteArray()
+
+                        val signature =
+                                c.sign(
+                                        KeyContext.Address,
+                                        0u,
+                                        0u,
+                                        0u,
+                                        data,
+                                        Bip32DerivationType.Khovratovich
+                                )
+
+                        assert(
+                                signature.contentEquals(
+                                        helperStringToByteArray(
+                                                "137,13,247,162,115,48,233,188,188,81,7,167,158,250,252,66,138,30,3,65,88,209,92,250,43,13,60,193,44,175,87,93,60,73,243,145,170,38,214,152,29,54,61,109,241,24,238,186,159,45,149,15,141,69,118,162,31,148,162,221,29,156,226,1"
+                                        )
+                                )
+                        ) { "Signature different from expected" }
+
+                        val pk =
+                                c.keyGen(
+                                        KeyContext.Address,
+                                        0u,
+                                        0u,
+                                        0u,
+                                        Bip32DerivationType.Khovratovich
+                                )
+
+                        assert(signature.size == 64) { "Signature size is not 64" }
+
+                        val isValid = c.verifyWithPublicKey(signature, data, pk)
+                        assert(isValid) { "signature is not valid" }
+
+                        val pk2 =
+                                c.keyGen(
+                                        KeyContext.Address,
+                                        0u,
+                                        0u,
+                                        1u,
+                                        Bip32DerivationType.Khovratovich
+                                )
+                        assert(!c.verifyWithPublicKey(signature, data, pk2)) {
+                                "signature is unexpectedly valid"
+                        }
+                }
+        }
+
+        @Nested
+        @TestInstance(TestInstance.Lifecycle.PER_CLASS)
         inner class SignTypedDataTests {
                 private lateinit var c: XHDWalletAPIJVM
 

--- a/sharedModule/src/main/kotlin/foundation/algorand/xhdwalletapi/XHDWalletAPIBase.kt
+++ b/sharedModule/src/main/kotlin/foundation/algorand/xhdwalletapi/XHDWalletAPIBase.kt
@@ -553,6 +553,7 @@ abstract class XHDWalletAPIBase(private var seed: ByteArray) {
    * @returns
    * - signature holding R and S, totally 64 bytes
    */
+  @Deprecated("signData is deprecated, please use sign() and validate data separately")
   fun signData(
           context: KeyContext,
           account: UInt,
@@ -582,14 +583,17 @@ abstract class XHDWalletAPIBase(private var seed: ByteArray) {
    * - context of the key (i.e Address, Identity)
    * @param account
    * - account number. This value will be hardened as part of BIP44
+   * @param change
+   * - change number. This value will be a SOFT derivation as part of BIP44, usually 0
    * @param keyIndex
    * - key index. This value will be a SOFT derivation as part of BIP44.
-   * @param tx
+   * @param prefixEncodedTx
    * - Transaction object containing parameters to be signed, e.g. sender, receiver, amount, fee,
    *
-   * @returns stx
-   * - SignedTransaction object
+   * @returns
+   * - signature holding R and S, totally 64 bytes
    */
+  @Deprecated("signAlgoTransaction is deprecated, please use sign()")
   fun signAlgoTransaction(
           context: KeyContext,
           account: UInt,
@@ -601,6 +605,35 @@ abstract class XHDWalletAPIBase(private var seed: ByteArray) {
     return rawSign(
             getBIP44PathFromContext(context, account, change, keyIndex),
             prefixEncodedTx,
+            derivationType
+    )
+  }
+
+  /**
+   * Sign bytes with the key derived from the context, account and keyIndex.
+   * @param context
+   * - context of the key (i.e Address, Identity)
+   * @param account
+   * - account number. This value will be hardened as part of BIP44
+   * @param keyIndex
+   * - key index. This value will be a SOFT derivation as part of BIP44.
+   * @param bytes
+   * - data to be signed in raw bytes
+   *
+   * @returns
+   * - signature holding R and S, totally 64 bytes
+   */
+  fun sign(
+          context: KeyContext,
+          account: UInt,
+          change: UInt,
+          keyIndex: UInt,
+          bytes: ByteArray,
+          derivationType: Bip32DerivationType = Bip32DerivationType.Peikert
+  ): ByteArray {
+    return rawSign(
+            getBIP44PathFromContext(context, account, change, keyIndex),
+            bytes,
             derivationType
     )
   }


### PR DESCRIPTION
- Deprecates signData and signAlgorandTransaction in favor of sign(), following discoveries of inconsistency between how Kotlin/Swift and TS handle the JSON validation. Swift has already had this introduced. 
https://github.com/algorandfoundation/xHD-Wallet-API-kt/issues/46
- Fixes maven signing issue preventing version from being uploaded