### PR TITLE
fix: gpg signing with GPG_PRIVATE_KEY

### DIFF
--- a/.github/workflows/build-and-release.yaml
+++ b/.github/workflows/build-and-release.yaml
@@ -73,6 +73,8 @@ jobs:
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: ./gradlew publishToMavenCentralPortal
 
       - name: Merge Release -> Trunk


### PR DESCRIPTION
# Overview

This adds GPG signing env variables to the maven release, it was triggering a signature causing the CI to fail without the GPG env.